### PR TITLE
[Feat] 알림 기능 구현 및 API 연동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { setAuthToken } from "./features/auth/authSlice";
 import LoginPage from "./pages/auth/LoginPage.jsx";
 import WorkerLayout from "./layouts/WorkerLayout.jsx";
 import EmployerLayout from "./layouts/EmployerLayout.jsx";
+import NotificationLayout from "./layouts/NotificationLayout.jsx";
 import WorkerMonthlyCalendarPage from "./pages/workers/WorkerMonthlyCalendarPage.jsx";
 import WorkerWeeklyCalendarPage from "./pages/workers/WorkerWeeklyCalendarPage.jsx";
 import WorkerRemittancePage from "./pages/workers/WorkerRemittancePage.jsx";
@@ -45,6 +46,7 @@ function App() {
         <Route path="/" element={<LoginPage />} />
         <Route path="/auth" element={<KakaoRedirect />} />
         <Route path="/signup" element={<SignupPage />} />
+        <Route path="/notifications" element={<NotificationLayout><NotificationPage /></NotificationLayout>} />
         <Route path="/worker" element={<WorkerLayout />}>
           <Route
             index

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -56,7 +56,6 @@ function App() {
           <Route path="weekly-calendar" element={<WorkerWeeklyCalendarPage />} />
           <Route path="remittance" element={<WorkerRemittancePage />} />
           <Route path="mypage" element={<WorkerMyPage />} />
-          <Route path="notifications" element={<NotificationPage />} />
         </Route>
 
         <Route path="/employer" element={<EmployerLayout />}>
@@ -73,7 +72,6 @@ function App() {
             path="employer-mypage-receive"
             element={<EmployerMyPageReceive />}
           />
-          <Route path="notifications" element={<NotificationPage />} />
         </Route>
 
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/api/httpClient.js
+++ b/src/api/httpClient.js
@@ -26,7 +26,7 @@ const getAuthHeaders = () => {
 // 새로운 access token을 저장하는 헬퍼 함수
 const saveNewAccessToken = (newAccessToken) => {
   localStorage.setItem('token', newAccessToken);
-  
+
   // Redux에 저장 (기존 userId, name, userType 유지)
   const currentState = store.getState().auth;
   store.dispatch(setAuthToken({
@@ -35,7 +35,7 @@ const saveNewAccessToken = (newAccessToken) => {
     name: currentState.name,
     userType: currentState.userType,
   }));
-  
+
 };
 
 // Refresh token 실패 시 로그아웃 처리 (idempotent)
@@ -44,19 +44,19 @@ const handleRefreshTokenFailure = () => {
   if (isHandlingRefreshFailure) {
     return;
   }
-  
+
   isHandlingRefreshFailure = true;
-  
+
   try {
     // localStorage 초기화
     localStorage.removeItem('token');
     localStorage.removeItem('userId');
     localStorage.removeItem('name');
     localStorage.removeItem('userType');
-    
+
     // Redux 초기화
     store.dispatch(clearAuth());
-    
+
     // 로그인 페이지로 리다이렉트
     if (typeof window !== 'undefined') {
       window.location.href = '/';
@@ -124,7 +124,7 @@ const httpClient = {
       handleNetworkError(error);
     }
   },
-  
+
   async post(url, data, options = {}) {
     try {
       const authHeaders = getAuthHeaders();
@@ -135,15 +135,15 @@ const httpClient = {
       if (options.headers && options.headers.Authorization === undefined) {
         delete headers.Authorization;
       }
-      
+
       // Content-Type이 명시적으로 설정되지 않았으면 application/json으로 설정
       if (!headers['Content-Type']) {
         headers['Content-Type'] = 'application/json';
       }
-      
+
       // options에서 headers를 제외한 나머지만 사용
       const { headers: _, ...restOptions } = options;
-      
+
       const fullUrl = `${API_BASE_URL}${url}`;
       const requestBody = JSON.stringify(data);
 
@@ -290,9 +290,9 @@ const httpClient = {
       }
     }
 
-    // 401 에러 처리: Refresh token으로 토큰 갱신 후 재시도
-    // 403(Forbidden)은 권한 문제(비즈니스 로직)일 수 있으므로 토큰 갱신/로그아웃을 트리거하지 않음
-    if (response.status === 401 && !originalRequest) {
+    // 401(Unauthorized) 또는 403(Forbidden) 에러 처리: Refresh token으로 토큰 갱신 후 재시도
+    // 403은 권한 문제일 수도 있지만, 사용자의 요청에 따라 토큰 갱신을 시도함
+    if ((response.status === 401 || response.status === 403) && !originalRequest) {
 
       // 이미 refresh token 요청 중이면 대기
       if (isRefreshing && refreshPromise) {
@@ -318,7 +318,7 @@ const httpClient = {
           throw refreshError;
         }
       }
-      
+
       // Refresh token 요청 시작
       isRefreshing = true;
       refreshPromise = refreshAccessToken()
@@ -334,7 +334,7 @@ const httpClient = {
           handleRefreshTokenFailure();
           throw refreshError;
         });
-      
+
       await refreshPromise;
       // 토큰 갱신 성공 - 원래 요청 재시도는 호출한 곳에서 처리
       throw {
@@ -351,14 +351,14 @@ const httpClient = {
         shouldRetry: true, // 재시도 플래그
       };
     }
-    
+
     // response.ok가 false이고, 응답 데이터에 success가 false이거나 없으면 에러로 처리
     if (!response.ok) {
       // 백엔드가 success: true로 응답하는 경우 (404도 정상 응답으로 처리)
       if (data.success === true) {
         return data;
       }
-      
+
       // success가 false이거나 없으면 에러로 throw
       const error = {
         ...data,
@@ -373,7 +373,7 @@ const httpClient = {
         errorMessage: data.error?.message,
         fullErrorData: data,
       };
-      
+
       console.error('[httpClient] 에러로 처리됨:', error);
       if (response.status === 500) {
         console.error('[httpClient] ⚠️ 500 서버 에러 상세 정보:');
@@ -383,10 +383,10 @@ const httpClient = {
         console.error('[httpClient] - 원본 응답 텍스트:', text);
         console.error('[httpClient] 💡 백엔드 로그를 확인하세요!');
       }
-      
+
       throw error;
     }
-    
+
     // 200 응답인 경우
     return data;
   },

--- a/src/api/notificationApi.js
+++ b/src/api/notificationApi.js
@@ -1,0 +1,18 @@
+import httpClient from './httpClient';
+
+/**
+ * 알림 목록 조회
+ * @param {Object} params - 쿼리 파라미터
+ * @param {number} params.size - 페이지 크기 (기본값: 4)
+ * @param {number} params.page - 페이지 번호 (기본값: 1)
+ * @returns {Promise<Object>} 알림 목록 응답
+ */
+export const getNotifications = async ({ size = 4, page = 1 } = {}) => {
+  const queryParams = new URLSearchParams({
+    size: size.toString(),
+    page: page.toString(),
+  });
+
+  const response = await httpClient.get(`/api/notifications?${queryParams}`);
+  return response;
+};

--- a/src/api/notificationApi.js
+++ b/src/api/notificationApi.js
@@ -36,3 +36,12 @@ export const markAllNotificationsAsRead = async () => {
   return response;
 };
 
+/**
+ * 알림 삭제
+ * @param {number} id - 알림 ID
+ * @returns {Promise<Object>} 삭제 응답
+ */
+export const deleteNotification = async (id) => {
+  const response = await httpClient.delete(`/api/notifications/${id}`);
+  return response;
+};

--- a/src/api/notificationApi.js
+++ b/src/api/notificationApi.js
@@ -16,3 +16,13 @@ export const getNotifications = async ({ size = 4, page = 1 } = {}) => {
   const response = await httpClient.get(`/api/notifications?${queryParams}`);
   return response;
 };
+
+/**
+ * 알림 읽음 처리
+ * @param {number} id - 알림 ID
+ * @returns {Promise<Object>} 읽음 처리 응답
+ */
+export const markNotificationAsRead = async (id) => {
+  const response = await httpClient.put(`/api/notifications/${id}/read`);
+  return response;
+};

--- a/src/api/notificationApi.js
+++ b/src/api/notificationApi.js
@@ -26,3 +26,13 @@ export const markNotificationAsRead = async (id) => {
   const response = await httpClient.put(`/api/notifications/${id}/read`);
   return response;
 };
+
+/**
+ * 전체 알림 읽음 처리
+ * @returns {Promise<Object>} 읽음 처리 응답
+ */
+export const markAllNotificationsAsRead = async () => {
+  const response = await httpClient.put('/api/notifications/read-all');
+  return response;
+};
+

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -11,6 +11,7 @@ import logoImage from "../../image/logo.png";
 
 export default function Header() {
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);
+  const [unreadCount, setUnreadCount] = useState(0);
   const notificationButtonRef = useRef(null);
   const dropdownRef = useRef(null);
   const dispatch = useDispatch();
@@ -29,25 +30,29 @@ export default function Header() {
     setIsNotificationOpen(false);
   };
 
+  const handleUnreadCountChange = (count) => {
+    setUnreadCount(count);
+  };
+
   const handleLogout = async () => {
     try {
       // 이미 정의된 accessToken 사용
       const response = await logout(accessToken);
-      
+
       // 200 응답인 경우
       if (response.success && response.data) {
         // Redux 상태 초기화
         dispatch(clearAuth());
-        
+
         // LocalStorage 초기화
         localStorage.removeItem('token');
         localStorage.removeItem('userId');
         localStorage.removeItem('name');
         localStorage.removeItem('userType');
-        
+
         // 성공 메시지 표시
         toast.success('로그아웃이 완료되었습니다.');
-        
+
         // 로그인 페이지로 이동
         navigate('/');
       } else {
@@ -57,7 +62,7 @@ export default function Header() {
         localStorage.removeItem('userId');
         localStorage.removeItem('name');
         localStorage.removeItem('userType');
-        
+
         const errorMessage = response.error?.message || '로그아웃 처리 중 오류가 발생했습니다.';
         const errorCode = response.error?.code || 'UNKNOWN';
         toast.error(`[${errorCode}] ${errorMessage}`);
@@ -70,16 +75,16 @@ export default function Header() {
       const errorCode = error.error?.code || error.errorCode || 'UNKNOWN';
       const statusCode = error.status || error.response?.status || '';
       const statusText = statusCode ? `[${statusCode}]` : '';
-      
+
       toast.error(`${statusText} [${errorCode}] ${errorMessage}`);
-      
+
       // 에러가 발생해도 로컬 상태는 초기화 (보안상 안전)
       dispatch(clearAuth());
       localStorage.removeItem('token');
       localStorage.removeItem('userId');
       localStorage.removeItem('name');
       localStorage.removeItem('userType');
-      
+
       // 로그인 페이지로 이동
       navigate('/');
     }
@@ -118,22 +123,26 @@ export default function Header() {
             onClick={toggleNotification}
           >
             <MdNotificationsNone />
+            {unreadCount > 0 && (
+              <span className="header-notification-badge">{unreadCount > 99 ? '99+' : unreadCount}</span>
+            )}
           </button>
           {isNotificationOpen && (
             <div ref={dropdownRef}>
               <NotificationDropdown
                 isOpen={isNotificationOpen}
                 onClose={closeNotification}
+                onUnreadCountChange={handleUnreadCountChange}
               />
             </div>
           )}
         </div>
         <span>{userName || '사용자'} 님</span>
-        <button 
+        <button
           onClick={handleLogout}
-          style={{ 
-            background: 'none', 
-            border: 'none', 
+          style={{
+            background: 'none',
+            border: 'none',
             cursor: 'pointer',
             color: 'inherit',
             textDecoration: 'underline'

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -20,6 +20,7 @@ export default function Header() {
   // Redux에서 사용자 정보 가져오기
   const authState = useSelector((state) => state.auth);
   const userName = authState.name;
+  const userType = authState.userType || localStorage.getItem('userType');
   const accessToken = authState.accessToken || localStorage.getItem('token');
 
   const toggleNotification = () => {
@@ -28,6 +29,14 @@ export default function Header() {
 
   const closeNotification = () => {
     setIsNotificationOpen(false);
+  };
+
+  const handleLogoClick = () => {
+    if (userType === 'EMPLOYER') {
+      navigate('/employer/daily-calendar');
+    } else {
+      navigate('/worker/monthly-calendar');
+    }
   };
 
   const handleUnreadCountChange = (count) => {
@@ -114,7 +123,13 @@ export default function Header() {
 
   return (
     <header className="header-bar">
-      <img src={logoImage} alt="월급 관리소" className="header-logo" />
+      <img
+        src={logoImage}
+        alt="월급 관리소"
+        className="header-logo"
+        onClick={handleLogoClick}
+        style={{ cursor: 'pointer' }}
+      />
       <div className="header-right">
         <div className="header-notification-wrapper" ref={notificationButtonRef}>
           <button

--- a/src/components/layout/NotificationDropdown.jsx
+++ b/src/components/layout/NotificationDropdown.jsx
@@ -3,25 +3,9 @@ import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import { MdNotificationsNone } from "react-icons/md";
 import { getNotifications, markNotificationAsRead } from "../../api/notificationApi";
+import { formatDateTime } from "../../utils/dateUtils";
 import "../../styles/notificationDropdown.css";
 
-/**
- * 서버 시간 포맷을 한국어 형식으로 변환
- * @param {string} dateString - ISO 형식의 날짜 문자열 (예: 2025-12-18T00:40:37.565902)
- * @returns {string} 한국어 형식의 날짜 문자열 (예: 2025년 12월 18일 00:40)
- */
-const formatDateTime = (dateString) => {
-  if (!dateString) return "";
-
-  const date = new Date(dateString);
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-
-  return `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
-};
 
 export default function NotificationDropdown({ isOpen, onClose, onUnreadCountChange }) {
   const navigate = useNavigate();

--- a/src/components/layout/NotificationDropdown.jsx
+++ b/src/components/layout/NotificationDropdown.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import { MdNotificationsNone } from "react-icons/md";
 import { getNotifications, markNotificationAsRead } from "../../api/notificationApi";
@@ -25,7 +25,6 @@ const formatDateTime = (dateString) => {
 
 export default function NotificationDropdown({ isOpen, onClose, onUnreadCountChange }) {
   const navigate = useNavigate();
-  const location = useLocation();
   const [notifications, setNotifications] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [unreadCount, setUnreadCount] = useState(0);
@@ -99,12 +98,7 @@ export default function NotificationDropdown({ isOpen, onClose, onUnreadCountCha
 
   const handleViewAll = () => {
     onClose();
-    // 현재 경로가 /worker 또는 /employer로 시작하는지 확인
-    if (location.pathname.startsWith("/worker")) {
-      navigate("/worker/notifications");
-    } else if (location.pathname.startsWith("/employer")) {
-      navigate("/employer/notifications");
-    }
+    navigate("/notifications");
   };
 
   if (!isOpen) return null;

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,7 @@ a {
   color: #646cff;
   text-decoration: inherit;
 }
+
 a:hover {
   color: #535bf2;
 }
@@ -46,9 +47,11 @@ button {
   cursor: pointer;
   transition: border-color 0.25s;
 }
+
 button:hover {
   border-color: #646cff;
 }
+
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
@@ -59,10 +62,21 @@ button:focus-visible {
     color: #213547;
     background-color: #ffffff;
   }
+
   a:hover {
     color: #747bff;
   }
+
   button {
     background-color: #f9f9f9;
   }
+}
+
+/* 사이드바 없는 메인 레이아웃 스타일 */
+.app-main {
+  width: 100%;
+  min-height: 100vh;
+  box-sizing: border-box;
+  padding-top: 80px;
+  background-color: #f7fbfc;
 }

--- a/src/layouts/NotificationLayout.jsx
+++ b/src/layouts/NotificationLayout.jsx
@@ -4,7 +4,7 @@ export default function NotificationLayout({ children }) {
   return (
     <>
       <Header />
-      <main className="app-main" style={{ paddingTop: "80px" }}>
+      <main className="app-main">
         {children}
       </main>
     </>

--- a/src/layouts/NotificationLayout.jsx
+++ b/src/layouts/NotificationLayout.jsx
@@ -1,0 +1,12 @@
+import Header from "../components/layout/Header.jsx";
+
+export default function NotificationLayout({ children }) {
+  return (
+    <>
+      <Header />
+      <main className="app-main" style={{ paddingTop: "80px" }}>
+        {children}
+      </main>
+    </>
+  );
+}

--- a/src/pages/NotificationPage.jsx
+++ b/src/pages/NotificationPage.jsx
@@ -7,18 +7,26 @@ import "../styles/notificationPage.css";
 
 
 export default function NotificationPage() {
+  const PAGE_SIZE = 20;
   const [notifications, setNotifications] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isMoreLoading, setIsMoreLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
 
   useEffect(() => {
-    fetchNotifications();
+    fetchNotifications(1);
   }, []);
 
-  const fetchNotifications = async () => {
-    setIsLoading(true);
+  const fetchNotifications = async (pageNum) => {
+    if (pageNum === 1) {
+      setIsLoading(true);
+    } else {
+      setIsMoreLoading(true);
+    }
+
     try {
-      // 전체 알림 조회 (size를 크게 설정)
-      const response = await getNotifications({ size: 100, page: 1 });
+      const response = await getNotifications({ size: PAGE_SIZE, page: pageNum });
 
       if (response.success && response.data) {
         const { notifications: apiNotifications } = response.data;
@@ -32,17 +40,38 @@ export default function NotificationPage() {
           icon: MdNotificationsNone,
         }));
 
-        setNotifications(formattedNotifications);
+        if (pageNum === 1) {
+          setNotifications(formattedNotifications);
+          // 첫 페이지 로드 시에만 전체 읽음 처리
+          await markAllAsRead();
+        } else {
+          setNotifications((prev) => {
+            // 중복 제거 후 추가
+            const existingIds = new Set(prev.map((n) => n.id));
+            const newNotifications = formattedNotifications.filter(
+              (n) => !existingIds.has(n.id)
+            );
+            return [...prev, ...newNotifications];
+          });
+        }
 
-        // 전체 알림 읽음 처리
-        await markAllAsRead();
+        // 더 불러올 데이터가 있는지 확인 (가져온 데이터가 요청한 사이즈보다 적으면 끝)
+        setHasMore(apiNotifications.length === PAGE_SIZE);
+        setPage(pageNum);
       }
     } catch (error) {
-      const errorMessage = error.error?.message || error.message || "알림을 불러오는데 실패했습니다.";
+      const errorMessage =
+        error.error?.message || error.message || "알림을 불러오는데 실패했습니다.";
       toast.error(errorMessage);
-      setNotifications([]);
     } finally {
       setIsLoading(false);
+      setIsMoreLoading(false);
+    }
+  };
+
+  const handleLoadMore = () => {
+    if (!isMoreLoading && hasMore) {
+      fetchNotifications(page + 1);
     }
   };
 
@@ -82,32 +111,43 @@ export default function NotificationPage() {
               <span>알림이 없습니다.</span>
             </div>
           ) : (
-            notifications.map((notification) => {
-              const Icon = notification.icon;
-              return (
-                <div key={notification.id} className="notification-page-item">
-                  <div className="notification-page-icon-wrapper">
-                    <Icon className="notification-page-icon" />
-                  </div>
-                  <div className="notification-page-content">
-                    <div className="notification-page-title-text">
-                      {notification.title}
+            <>
+              {notifications.map((notification) => {
+                const Icon = notification.icon;
+                return (
+                  <div key={notification.id} className="notification-page-item">
+                    <div className="notification-page-icon-wrapper">
+                      <Icon className="notification-page-icon" />
                     </div>
-                    <div className="notification-page-bottom">
-                      <span className="notification-page-time">
-                        {notification.time}
-                      </span>
-                      <span
-                        className="notification-page-delete"
-                        onClick={() => handleDelete(notification.id)}
-                      >
-                        삭제하기
-                      </span>
+                    <div className="notification-page-content">
+                      <div className="notification-page-title-text">
+                        {notification.title}
+                      </div>
+                      <div className="notification-page-bottom">
+                        <span className="notification-page-time">
+                          {notification.time}
+                        </span>
+                        <span
+                          className="notification-page-delete"
+                          onClick={() => handleDelete(notification.id)}
+                        >
+                          삭제하기
+                        </span>
+                      </div>
                     </div>
                   </div>
-                </div>
-              );
-            })
+                );
+              })}
+              {hasMore && (
+                <button
+                  className="notification-load-more"
+                  onClick={handleLoadMore}
+                  disabled={isMoreLoading}
+                >
+                  {isMoreLoading ? "불러오는 중..." : "더 보기"}
+                </button>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/src/pages/NotificationPage.jsx
+++ b/src/pages/NotificationPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { toast } from "react-toastify";
 import { MdNotificationsNone } from "react-icons/md";
-import { getNotifications, markAllNotificationsAsRead } from "../api/notificationApi";
+import { getNotifications, markAllNotificationsAsRead, deleteNotification } from "../api/notificationApi";
 import "../styles/notificationPage.css";
 
 /**
@@ -71,6 +71,18 @@ export default function NotificationPage() {
     }
   };
 
+  const handleDelete = async (id) => {
+    try {
+      await deleteNotification(id);
+      toast.success("알림이 삭제되었습니다.");
+      // 삭제된 알림을 목록에서 제거
+      setNotifications((prev) => prev.filter((n) => n.id !== id));
+    } catch (error) {
+      const errorMessage = error.error?.message || error.message || "알림 삭제에 실패했습니다.";
+      toast.error(errorMessage);
+    }
+  };
+
   return (
     <div className="notification-page">
       <div className="notification-page-container">
@@ -97,8 +109,16 @@ export default function NotificationPage() {
                     <div className="notification-page-title-text">
                       {notification.title}
                     </div>
-                    <div className="notification-page-time">
-                      {notification.time}
+                    <div className="notification-page-bottom">
+                      <span className="notification-page-time">
+                        {notification.time}
+                      </span>
+                      <span
+                        className="notification-page-delete"
+                        onClick={() => handleDelete(notification.id)}
+                      >
+                        삭제하기
+                      </span>
                     </div>
                   </div>
                 </div>

--- a/src/pages/NotificationPage.jsx
+++ b/src/pages/NotificationPage.jsx
@@ -2,25 +2,9 @@ import React, { useState, useEffect } from "react";
 import { toast } from "react-toastify";
 import { MdNotificationsNone } from "react-icons/md";
 import { getNotifications, markAllNotificationsAsRead, deleteNotification } from "../api/notificationApi";
+import { formatDateTime } from "../utils/dateUtils";
 import "../styles/notificationPage.css";
 
-/**
- * 서버 시간 포맷을 한국어 형식으로 변환
- * @param {string} dateString - ISO 형식의 날짜 문자열
- * @returns {string} 한국어 형식의 날짜 문자열
- */
-const formatDateTime = (dateString) => {
-  if (!dateString) return "";
-
-  const date = new Date(dateString);
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-
-  return `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
-};
 
 export default function NotificationPage() {
   const [notifications, setNotifications] = useState([]);

--- a/src/pages/NotificationPage.jsx
+++ b/src/pages/NotificationPage.jsx
@@ -1,66 +1,112 @@
-import React from "react";
-import { MdMic, MdAttachFile } from "react-icons/md";
+import React, { useState, useEffect } from "react";
+import { toast } from "react-toastify";
+import { MdNotificationsNone } from "react-icons/md";
+import { getNotifications, markAllNotificationsAsRead } from "../api/notificationApi";
 import "../styles/notificationPage.css";
 
+/**
+ * 서버 시간 포맷을 한국어 형식으로 변환
+ * @param {string} dateString - ISO 형식의 날짜 문자열
+ * @returns {string} 한국어 형식의 날짜 문자열
+ */
+const formatDateTime = (dateString) => {
+  if (!dateString) return "";
+
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+
+  return `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
+};
+
 export default function NotificationPage() {
-  // 임시 알림 데이터 (나중에 API로 교체)
-  const notifications = [
-    {
-      id: 1,
-      type: "announcement",
-      title: "시스템 프로그래밍[202502-CSE3209-002]",
-      message: "새 공지사항이 등록되었습니다.",
-      icon: MdMic,
-    },
-    {
-      id: 2,
-      type: "file",
-      title: "시스템 프로그래밍[202502-CSE3209-002]",
-      message: "새 파일이(가) 등록되었습니다.",
-      icon: MdAttachFile,
-    },
-    {
-      id: 3,
-      type: "file",
-      title: "시스템 프로그래밍[202502-CSE3209-002]",
-      message: "새 파일이(가) 등록되었습니다.",
-      icon: MdAttachFile,
-    },
-    {
-      id: 4,
-      type: "file",
-      title: "이산구조[202502-CSE1312-005]",
-      message: "새 파일이(가) 등록되었습니다.",
-      icon: MdAttachFile,
-    },
-  ];
+  const [notifications, setNotifications] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetchNotifications();
+  }, []);
+
+  const fetchNotifications = async () => {
+    setIsLoading(true);
+    try {
+      // 전체 알림 조회 (size를 크게 설정)
+      const response = await getNotifications({ size: 100, page: 1 });
+
+      if (response.success && response.data) {
+        const { notifications: apiNotifications } = response.data;
+
+        // API 응답을 컴포넌트 형식으로 변환
+        const formattedNotifications = apiNotifications.map((notification) => ({
+          id: notification.id,
+          type: notification.type,
+          title: notification.title,
+          time: formatDateTime(notification.createdAt),
+          icon: MdNotificationsNone,
+        }));
+
+        setNotifications(formattedNotifications);
+
+        // 전체 알림 읽음 처리
+        await markAllAsRead();
+      }
+    } catch (error) {
+      const errorMessage = error.error?.message || error.message || "알림을 불러오는데 실패했습니다.";
+      toast.error(errorMessage);
+      setNotifications([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const markAllAsRead = async () => {
+    try {
+      await markAllNotificationsAsRead();
+    } catch (error) {
+      const errorMessage = error.error?.message || error.message || "알림 읽음 처리에 실패했습니다.";
+      toast.error(errorMessage);
+    }
+  };
 
   return (
     <div className="notification-page">
       <div className="notification-page-container">
         <h1 className="notification-page-title">전체 알림</h1>
         <div className="notification-page-list">
-          {notifications.map((notification) => {
-            const Icon = notification.icon;
-            return (
-              <div key={notification.id} className="notification-page-item">
-                <div className="notification-page-icon-wrapper">
-                  <Icon className="notification-page-icon" />
-                </div>
-                <div className="notification-page-content">
-                  <div className="notification-page-title-text">
-                    {notification.title}
+          {isLoading ? (
+            <div className="notification-page-loading">
+              <div className="notification-page-spinner"></div>
+              <span>알림을 불러오는 중...</span>
+            </div>
+          ) : notifications.length === 0 ? (
+            <div className="notification-page-empty">
+              <span>알림이 없습니다.</span>
+            </div>
+          ) : (
+            notifications.map((notification) => {
+              const Icon = notification.icon;
+              return (
+                <div key={notification.id} className="notification-page-item">
+                  <div className="notification-page-icon-wrapper">
+                    <Icon className="notification-page-icon" />
                   </div>
-                  <div className="notification-page-message">
-                    {notification.message}
+                  <div className="notification-page-content">
+                    <div className="notification-page-title-text">
+                      {notification.title}
+                    </div>
+                    <div className="notification-page-time">
+                      {notification.time}
+                    </div>
                   </div>
                 </div>
-              </div>
-            );
-          })}
+              );
+            })
+          )}
         </div>
       </div>
     </div>
   );
 }
-

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -1,7 +1,8 @@
 /* 상단 헤더 스타일 */
 .header-bar {
   width: 100%;
-  background-color: #769fcd; /* 이미지의 상단 바 색상 */
+  background-color: #769fcd;
+  /* 이미지의 상단 바 색상 */
   color: white;
   padding: 15px 30px;
   display: flex;
@@ -28,7 +29,7 @@
   object-fit: contain;
 }
 
-.header-bar > div,
+.header-bar>div,
 .header-right {
   display: flex;
   align-items: center;
@@ -68,4 +69,23 @@
 
 .header-bar a:hover {
   text-decoration: underline;
+}
+
+/* 알림 배지 */
+.header-notification-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: #ef4444;
+  color: white;
+  font-size: 10px;
+  font-weight: 600;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
 }

--- a/src/styles/notificationDropdown.css
+++ b/src/styles/notificationDropdown.css
@@ -164,3 +164,51 @@
   background: #9ca3af;
 }
 
+/* 로딩 상태 */
+.notification-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  color: #6b7280;
+}
+
+.notification-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid #e5e7eb;
+  border-top-color: #769fcd;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-bottom: 12px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* 빈 상태 */
+.notification-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  color: #9ca3af;
+  font-size: 14px;
+}
+
+/* 읽지 않은 알림 배지 (드롭다운 헤더) */
+.notification-unread-badge {
+  background-color: #ef4444;
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  min-width: 20px;
+  text-align: center;
+}
+

--- a/src/styles/notificationPage.css
+++ b/src/styles/notificationPage.css
@@ -86,9 +86,27 @@
   white-space: nowrap;
 }
 
+.notification-page-bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .notification-page-time {
   font-size: 12px;
   color: #9ca3af;
+}
+
+.notification-page-delete {
+  font-size: 12px;
+  color: #6b7280;
+  text-decoration: underline;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.notification-page-delete:hover {
+  color: #ef4444;
 }
 
 /* 로딩 상태 */

--- a/src/styles/notificationPage.css
+++ b/src/styles/notificationPage.css
@@ -91,3 +91,38 @@
   color: #9ca3af;
 }
 
+/* 로딩 상태 */
+.notification-page-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+  color: #6b7280;
+}
+
+.notification-page-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #e5e7eb;
+  border-top-color: #769fcd;
+  border-radius: 50%;
+  animation: notification-page-spin 0.8s linear infinite;
+  margin-bottom: 16px;
+}
+
+@keyframes notification-page-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* 빈 상태 */
+.notification-page-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+  color: #9ca3af;
+  font-size: 16px;
+}

--- a/src/styles/notificationPage.css
+++ b/src/styles/notificationPage.css
@@ -144,3 +144,29 @@
   color: #9ca3af;
   font-size: 16px;
 }
+
+/* 더 보기 버튼 */
+.notification-load-more {
+  width: 100%;
+  padding: 12px;
+  margin-top: 16px;
+  background-color: transparent;
+  border: 1px solid #d1d5db;
+  color: #6b7280;
+  border-radius: 6px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.notification-load-more:hover:not(:disabled) {
+  background-color: #f3f4f6;
+  color: #374151;
+  border-color: #9ca3af;
+}
+
+.notification-load-more:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: #f9fafb;
+}

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -34,7 +34,7 @@ export const formatDateToMonthDay = (dateString) => {
 // 시간 형식 변환 함수 ({hour, minute} 또는 "HH:mm:ss" -> "HH:MM")
 export const formatTime = (timeObj) => {
   if (!timeObj) return "";
-  
+
   // 문자열 형식인 경우 ("HH:mm:ss" -> "HH:mm")
   if (typeof timeObj === "string") {
     try {
@@ -46,27 +46,27 @@ export const formatTime = (timeObj) => {
       return "";
     }
   }
-  
+
   // 객체 형식인 경우 ({hour, minute} -> "HH:mm")
   if (timeObj.hour !== undefined && timeObj.minute !== undefined) {
     const hour = String(timeObj.hour).padStart(2, "0");
     const minute = String(timeObj.minute).padStart(2, "0");
     return `${hour}:${minute}`;
   }
-  
+
   return "";
 };
 
 // 날짜 문자열을 숫자와 요일로 변환 ("2025-12-17" -> { date: 17, day: "수" })
 export const parseWorkDate = (dateString) => {
   if (!dateString) return { date: 0, day: "" };
-  
+
   try {
     const [year, month, day] = dateString.split("-").map(Number);
     const date = new Date(year, month - 1, day);
     const dayIndex = date.getDay();
     const dayLabels = ["일", "월", "화", "수", "목", "금", "토"];
-    
+
     return {
       date: day,
       day: dayLabels[dayIndex] || "",
@@ -76,3 +76,21 @@ export const parseWorkDate = (dateString) => {
   }
 };
 
+
+/**
+ * 서버 시간 포맷을 한국어 형식으로 변환
+ * @param {string} dateString - ISO 형식의 날짜 문자열
+ * @returns {string} 한국어 형식의 날짜 문자열
+ */
+export const formatDateTime = (dateString) => {
+  if (!dateString) return "";
+
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+
+  return `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
+};


### PR DESCRIPTION
## 📌 Issue number and Link
closed #50

## ✏️ Summary
근로자 알림 기능 API 연동 구현. 헤더의 알림 드롭다운과 알림 전체 페이지를 실제 API와 연동하고, 읽음 처리 및 삭제 기능을 추가했습니다.

## 📝 Changes

### API 연동 ([notificationApi.js]
- 알림 목록 조회 (GET /api/notifications)
- 개별 알림 읽음 처리 (PUT /api/notifications/{id}/read)
- 전체 알림 읽음 처리 (PUT /api/notifications/read-all)
- 알림 삭제 (DELETE /api/notifications/{id})

### 알림 드롭다운 ([NotificationDropdown.jsx]
- 더미 데이터 → API 연동으로 변경
- 최대 4개 알림 최신순 표시
- 드롭다운 열릴 때 표시된 알림 자동 읽음 처리
- 로딩 스피너 추가
- 에러 발생 시 react-toastify로 메시지 표시
- 시간 포맷 변환 (ISO → "2025년 12월 18일 00:40" 형식)
- 읽지 않은 알림 개수 배지 표시 (헤더 아이콘 + 드롭다운 헤더)

### 알림 전체 페이지 ([NotificationPage.jsx]
- 더미 데이터 → API 연동으로 변경
- 전체 알림 목록 최신순 표시
- 페이지 진입 시 전체 읽음 처리
- 각 알림마다 "삭제하기" 링크 추가

### 라우팅 변경
- `/notifications` 통합 라우트 추가 (근로자/고용주 구분 제거)

### UI/UX 개선
- 알림 아이콘 변경 (MdMic → MdNotificationsNone)
- 로딩/빈 상태 UI 추가
- 헤더 알림 배지 스타일 추가 (99+ 처리)

## 🔎 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 헤더에 클릭 가능한 로고 이동 및 읽지 않은 알림 뱃지(99+ 포함) 표시
  * 드롭다운과 전용 /notifications 페이지에서 API 기반 실시간 알림 조회, 삭제, 단건·일괄 읽음 처리, 로딩·빈 상태 UI, 한국식 날짜/시간 표시
  * 공통 알림 레이아웃 추가로 통일된 알림 화면 제공

* **버그 수정 / 개선**
  * 로그아웃 및 인증 갱신 흐름 개선으로 세션 안정성 및 오류 처리 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->