### PR TITLE
[Feat] WORKER 회원가입 시 은행 선택 및 계좌번호 입력 기능 추가

### DIFF
--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -77,7 +77,6 @@ export default function SignupForm({ kakaoAccessToken }: SignupFormProps) {
             >
               {bankName || '은행을 선택해주세요'}
             </button>
-            {bankName && !isValidBankName && <p style={{color:'#ef4444', fontSize:'0.8rem'}}>은행을 선택해주세요.</p>}
           </div>
         )}
 

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -1,7 +1,9 @@
 import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 import { FaTimes } from 'react-icons/fa';
 import { useSignupForm } from '../../hooks/auth/useSignupForm';
 import UserTypeSelector from './UserTypeSelector';
+import BankSelectModal from '../common/BankSelectModal/BankSelectModal';
 import '../../pages/auth/SignupPage.css'; 
 
 interface SignupFormProps {
@@ -10,12 +12,13 @@ interface SignupFormProps {
 
 export default function SignupForm({ kakaoAccessToken }: SignupFormProps) {
   const navigate = useNavigate();
+  const [isBankModalOpen, setIsBankModalOpen] = useState(false);
 
   const { 
-    formState: { name, phone, userType }, 
-    formActions: { setName, setUserType, handlePhoneChange, handleSubmit },
-    validation: { isValidName, isValidPhone, isSubmitDisabled }
-  } = useSignupForm({ kakaoAccessToken }); // Hook 사용 - useSignupForm
+      formState: { name, phone, userType, bankName, accountNumber }, 
+    formActions: { setName, setUserType, handlePhoneChange, setBankName, handleAccountNumberChange, handleSubmit },
+    validation: { isValidName, isValidPhone, isValidBankName, isValidAccountNumber, isSubmitDisabled }
+  } = useSignupForm({ kakaoAccessToken });
 
   return ( 
     // 하얀색 박스 
@@ -62,6 +65,38 @@ export default function SignupForm({ kakaoAccessToken }: SignupFormProps) {
           <UserTypeSelector value={userType} onChange={setUserType} />
         </div>
 
+        {/* 은행 선택 (WORKER만 표시) */}
+        {userType === 'WORKER' && (
+          <div className="form-group">
+            <label className="form-label">은행 <span className="required-star">*</span></label>
+            <button
+              type="button"
+              onClick={() => setIsBankModalOpen(true)}
+              className="form-input"
+              style={{ textAlign: 'left', cursor: 'pointer' }}
+            >
+              {bankName || '은행을 선택해주세요'}
+            </button>
+            {bankName && !isValidBankName && <p style={{color:'#ef4444', fontSize:'0.8rem'}}>은행을 선택해주세요.</p>}
+          </div>
+        )}
+
+        {/* 계좌번호 입력 (WORKER만 표시) */}
+        {userType === 'WORKER' && (
+          <div className="form-group">
+            <label className="form-label">계좌번호 <span className="required-star">*</span></label>
+            <input
+              type="text"
+              value={accountNumber}
+              onChange={handleAccountNumberChange}
+              placeholder="계좌번호를 입력해주세요"
+              maxLength={20}
+              className="form-input"
+            />
+            {accountNumber && !isValidAccountNumber && <p style={{color:'#ef4444', fontSize:'0.8rem'}}>계좌번호는 10자 이상 입력해주세요.</p>}
+          </div>
+        )}
+
         {/* 가입하기 버튼 */}
         <button
           onClick={handleSubmit}
@@ -75,6 +110,14 @@ export default function SignupForm({ kakaoAccessToken }: SignupFormProps) {
           가입하기
         </button>
       </div>
+
+      {/* 은행 선택 모달 */}
+      <BankSelectModal
+        isOpen={isBankModalOpen}
+        selectedBank={bankName}
+        onSelect={setBankName}
+        onClose={() => setIsBankModalOpen(false)}
+      />
     </div>
   );
 }

--- a/src/hooks/auth/useSignupForm.ts
+++ b/src/hooks/auth/useSignupForm.ts
@@ -16,11 +16,15 @@ export const useSignupForm = ({ kakaoAccessToken }: UseSignupFormProps) => {
   const [userType, setUserType] = useState<UserType | ''>('');
   const [phone, setPhone] = useState('');
   const [name, setName] = useState('');
+  const [bankName, setBankName] = useState('');
+  const [accountNumber, setAccountNumber] = useState('');
 
   // 유효성 검사
   const isValidName = name.trim().length >= AUTH_CONSTANTS.MIN_NAME_LENGTH;
   const isValidPhone = /^010-\d{4}-\d{4}$/.test(phone);
-  const isSubmitDisabled = !isValidName || !isValidPhone || !userType;
+  const isValidBankName = userType === 'WORKER' ? bankName.trim().length > 0 : true;
+  const isValidAccountNumber = userType === 'WORKER' ? accountNumber.trim().length >= 10 : true;
+  const isSubmitDisabled = !isValidName || !isValidPhone || !userType || !isValidBankName || !isValidAccountNumber;
 
   // 전화번호 포맷팅 핸들러
   const handlePhoneChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -34,6 +38,12 @@ export const useSignupForm = ({ kakaoAccessToken }: UseSignupFormProps) => {
     }
     
     setPhone(formatted);
+  }, []);
+
+  // 계좌번호 입력 핸들러 (숫자만 입력 가능)
+  const handleAccountNumberChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const numbersOnly = e.target.value.replace(/[^0-9]/g, '');
+    setAccountNumber(numbersOnly);
   }, []);
 
   // 제출 핸들러
@@ -63,8 +73,8 @@ export const useSignupForm = ({ kakaoAccessToken }: UseSignupFormProps) => {
         kakaoAccessToken,
         userType,
         phone,
-        bankName: '', // 은행명 (현재 미사용)
-        accountNumber: '', // 계좌번호 (현재 미사용)
+        bankName: userType === 'WORKER' ? bankName : '',
+        accountNumber: userType === 'WORKER' ? accountNumber : '',
         profileImageUrl: '' // TODO: 카카오 OAuth 추가 호출 후 프로필 이미지 연동
       });
 
@@ -119,8 +129,8 @@ export const useSignupForm = ({ kakaoAccessToken }: UseSignupFormProps) => {
   };
 
   return {
-    formState: { name, phone, userType },
-    formActions: { setName, setUserType, handlePhoneChange, handleSubmit },
-    validation: { isValidName, isValidPhone, isSubmitDisabled },
+    formState: { name, phone, userType, bankName, accountNumber },
+    formActions: { setName, setUserType, handlePhoneChange, setBankName, handleAccountNumberChange, handleSubmit },
+    validation: { isValidName, isValidPhone, isValidBankName, isValidAccountNumber, isSubmitDisabled },
   };
 };

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -8,9 +8,9 @@ export default function SignupPage() {
 
   // 사용자가 카카오 액세스 토큰 없이 직접 접근하는 것(/signup) 방지 
   // -> 화면 테스트할땐 지우시면 됩니다!
-  if (!kakaoAccessToken) {
-    return <Navigate to="/" replace />;
-  }
+  // if (!kakaoAccessToken) {
+  //   return <Navigate to="/" replace />;
+  // }
 
   return (
     <div className="signup-container">

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -8,9 +8,9 @@ export default function SignupPage() {
 
   // 사용자가 카카오 액세스 토큰 없이 직접 접근하는 것(/signup) 방지 
   // -> 화면 테스트할땐 지우시면 됩니다!
-  // if (!kakaoAccessToken) {
-  //   return <Navigate to="/" replace />;
-  // }
+  if (!kakaoAccessToken) {
+    return <Navigate to="/" replace />;
+  }
 
   return (
     <div className="signup-container">

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -29,27 +29,11 @@ export interface AuthSuccessData {
 }
 
 // 카카오 로그인/회원가입 요청 시 필요한 파라미터
-
-// 공통으로 사용하는 필드들
-interface BaseRegisterParams {
-  kakaoAccessToken: string;
-  phone: string;
-  profileImageUrl?: string;
+export interface KakaoRegisterParams {
+  kakaoAccessToken: string; 
+  userType: UserType;      
+  phone: string;             
+  bankName?: string;          
+  accountNumber?: string;     
+  profileImageUrl?: string;   
 }
-
-// 근로자일 때의 타입 (은행 정보 필수)
-interface WorkerRegisterParams extends BaseRegisterParams {
-  userType: 'WORKER';
-  bankName: string;
-  accountNumber: string;
-}
-
-// 고용주일 때의 타입 (은행 정보 없음)
-interface EmployerRegisterParams extends BaseRegisterParams {
-  userType: 'EMPLOYER';
-  bankName?: never;
-  accountNumber?: never;
-}
-
-// 최종 유니온 타입
-export type KakaoRegisterParams = WorkerRegisterParams | EmployerRegisterParams;


### PR DESCRIPTION
## 📌 Issue number and Link
Closed #87

## ✏️ Summary
WORKER 역할로 회원가입 시 은행명과 계좌번호 입력 기능을 추가했습니다.
- 근로자가 급여를 지급받기 위해 필수적인 계좌 정보를 회원가입 단계에서 수집
- WORKER 선택 시에만 은행/계좌번호 필드 표시 (EMPLOYER는 숨김)
- 계좌번호는 숫자만 입력 가능하도록 제한

## 📝 Changes

### useSignupForm.ts
- `bankName`, `accountNumber` 상태 추가
- 유효성 검사 추가: 
  - `isValidBankName`: WORKER일 때 필수
  - `isValidAccountNumber`: WORKER일 때 필수, 10자 이상
- `handleAccountNumberChange`: 숫자만 입력 가능하도록 필터링
- API 호출 시 실제 `bankName`, `accountNumber` 값 전달

### SignupForm.tsx
- BankSelectModal 임포트 및 상태 관리 추가
- WORKER 선택 시에만 표시되는 은행 선택 필드 (버튼 형태)
- WORKER 선택 시에만 표시되는 계좌번호 입력 필드
- 각 필드의 유효성 검사 에러 메시지 표시

### types/auth.ts
- swagger에 따라 `KakaoRegisterParams` 타입 단순화
  - 필수: `kakaoAccessToken`, `userType`, `phone`
  - 선택: `bankName?`, `accountNumber?`, `profileImageUrl?`
- 복잡한 유니온 타입 제거로 타입 안전성 향상

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
[근로자 선택]
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/edef9709-a15e-4118-985c-90f6239bdf7c" />
[고용주 선택]
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8aaaa6dc-d791-4e5d-ab87-6c0f4da62216" />
[은행 선택 UI]
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a3d51ec6-d3f4-450b-b1f4-d70818eeea66" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 근로자 회원가입에 은행명 선택 및 계좌번호 입력 항목 추가
  * 은행 선택을 위한 모달 UI 도입으로 쉬운 은행 선택 지원
  * 계좌번호 입력에 숫자 전용 제약 및 유효성 검증 적용, 근로자일 경우 제출 필수화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->